### PR TITLE
Support Duplicate Query String Keys

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -185,7 +185,7 @@ export function parseQuery(str = '', { decode = decodeURIComponent } = {}) {
 					let o = parseKeys(key, val);
 					obj = Object.keys(o).reduce((obj, key) => {
 						const val = prefs.convertTypes ? convertType(o[key]) : o[key];
-						if (obj[key]) {
+						if (obj[key] && typeof obj[key] != 'string') {
 							Array.isArray(obj[key])
 								? (obj[key] = obj[key].concat(val))
 								: Object.assign(obj[key], val);


### PR DESCRIPTION
`/my-page?foo=bar&foo=bar` results in an error caused by calling `Object.assign(obj[key], val)` on an existing string
> Uncaught TypeError: Cannot assign to read only property '0' of object '[object String]'


According to RFC 3986, which defines the URI (Uniform Resource Identifier) syntax, the query component can include duplicate keys.  Instead of erroring, ignore duplicates.
>The query component is defined as a string of characters beginning with a ? and consisting of a series of key=value pairs, each of which is separated by an &. In the case where multiple pairs with the same key exist, the behavior is application-specific, and it's up to the server or client to define how they handle such cases.

