### PR TITLE
Fix exports types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "svelte-pathfinder",
-    "version": "4.7.1",
+    "version": "4.8.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "svelte-pathfinder",
-            "version": "4.7.1",
+            "version": "4.8.1",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "^7.22.9",
@@ -8534,18 +8534,6 @@
                 "node": ">= 8"
             }
         },
-<<<<<<< HEAD
-        "node_modules/word-wrap": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-=======
->>>>>>> 0ff1da5 (Add support for Svelte 4)
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -14903,15 +14891,6 @@
                 "isexe": "^2.0.0"
             }
         },
-<<<<<<< HEAD
-        "word-wrap": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "dev": true
-        },
-=======
->>>>>>> 0ff1da5 (Add support for Svelte 4)
         "wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "svelte": "src/index.js",
     "exports": {
         ".": {
-            "svelte": "./src/index.js"
+            "svelte": "./src/index.js",
+            "types": "src/index.d.ts"
         }
     },
     "types": "src/index.d.ts",


### PR DESCRIPTION
Fixes `Cannot find module 'svelte-pathfinder' or its corresponding type declarations` errors when importing from `svelte-pathfinder` in `<script lang="ts">` blocks in Svelte project.

Also, running `npm install` cleaned up conflicts and old version in `package-lock.json`.